### PR TITLE
Fix ERR_CLEARTEXT_NOT_PERMITTED on translate

### DIFF
--- a/app/src/main/java/com/klinker/android/twitter_l/settings/AppSettings.java
+++ b/app/src/main/java/com/klinker/android/twitter_l/settings/AppSettings.java
@@ -512,7 +512,7 @@ public class AppSettings {
         activityRefresh = Long.parseLong(sharedPrefs.getString("activity_sync_interval", "0"));
         listRefresh = Long.parseLong(sharedPrefs.getString("list_sync_interval", "0"));
 
-        translateUrl = sharedPrefs.getString("translate_url", "http://translate.google.com/#auto|en|");
+        translateUrl = sharedPrefs.getString("translate_url", "https://translate.google.com/#auto|en|");
 
         if (baseTheme != 2 && sharedPrefs.getBoolean("night_mode", false)) {
             int startHour = sharedPrefs.getInt("night_start_hour", 22);


### PR DESCRIPTION
Hi!

I tried to translate a tweet, but the webview returned me that error.
![photo5848223965443632434](https://user-images.githubusercontent.com/843787/41498025-0db9dbc6-7163-11e8-9ad8-f4d0ab89a0aa.jpg)

I'm running the latest Android P (beta), which doesn't allow cleartext connections anymore.
So the fix is pretty simple here: don't use insecure connections. :wink: 