### PR TITLE
Avoid unmuted users to be showed as if they are muted

### DIFF
--- a/app/src/main/java/com/klinker/android/twitter_l/activities/profile_viewer/ProfilePager.java
+++ b/app/src/main/java/com/klinker/android/twitter_l/activities/profile_viewer/ProfilePager.java
@@ -753,8 +753,8 @@ public class ProfilePager extends WhiteToolbarActivity implements DragDismissDel
                         sharedPrefs.edit().putString("profile_pic_url_" + settings.currentAccount, thisUser.getOriginalProfileImageURL()).apply();
                         sharedPrefs.edit().putString("twitter_background_url_" + settings.currentAccount, thisUser.getProfileBannerURL()).apply();
                         isMuffled = sharedPrefs.getStringSet("muffled_users", new HashSet<>()).contains(screenName);
-                        isMuted = sharedPrefs.getString("muted_users", "").toLowerCase().contains(screenName.toLowerCase());
-                        isRTMuted = sharedPrefs.getString("muted_rts", "").toLowerCase().contains(screenName.toLowerCase());
+                        isMuted = sharedPrefs.getString("muted_users", "").toLowerCase().contains(screenName.toLowerCase() + " ");
+                        isRTMuted = sharedPrefs.getString("muted_rts", "").toLowerCase().contains(screenName.toLowerCase() + " ");
                     }
                 } else {
                     try {
@@ -765,8 +765,8 @@ public class ProfilePager extends WhiteToolbarActivity implements DragDismissDel
                         isFollowing = friendship.isSourceFollowingTarget();
                         followingYou = friendship.isTargetFollowingSource();
                         isBlocking = friendship.isSourceBlockingTarget();
-                        isMuted = sharedPrefs.getString("muted_users", "").toLowerCase().contains(screenName.toLowerCase());
-                        isRTMuted = sharedPrefs.getString("muted_rts", "").toLowerCase().contains(screenName.toLowerCase());
+                        isMuted = sharedPrefs.getString("muted_users", "").toLowerCase().contains(screenName.toLowerCase() + " ");
+                        isRTMuted = sharedPrefs.getString("muted_rts", "").toLowerCase().contains(screenName.toLowerCase() + " ");
                         isMuffled = sharedPrefs.getStringSet("muffled_users", new HashSet<String>()).contains(screenName);
                         isFavorite = FavoriteUsersDataSource.getInstance(context).isFavUser(otherUserName);
 
@@ -970,8 +970,8 @@ public class ProfilePager extends WhiteToolbarActivity implements DragDismissDel
 
                     isFollowing = friendship.isSourceFollowingTarget();
                     isBlocking = friendship.isSourceBlockingTarget();
-                    isMuted = sharedPrefs.getString("muted_users", "").contains(screenName);
-                    isRTMuted = sharedPrefs.getString("muted_rts", "").contains(screenName);
+                    isMuted = sharedPrefs.getString("muted_users", "").contains(screenName + " ");
+                    isRTMuted = sharedPrefs.getString("muted_rts", "").contains(screenName + " ");
                     isFavorite = FavoriteUsersDataSource.getInstance(context).isFavUser(otherUserName);
                     isFollowingSet = true;
 


### PR DESCRIPTION
Screen names are put on the SharedPreference after concatenated with `" "`,  so they should be evaluated with space-concatenated screen names.

This fixes #109