### PR TITLE
Deleted Tweet Marker

### DIFF
--- a/secrets.properties.sample
+++ b/secrets.properties.sample
@@ -33,7 +33,6 @@ YOUTUBE_API_KEY=""
 # If you wish to use these services, You will need to get a key for them, on your own.
 #
 
-TWEETMARKER_KEY=""
 TWITLONGER_KEY=""
 MERCURY_KEY=""
 


### PR DESCRIPTION
Since the API doesn't work any longer.

https://www.tweetmarker.net/
https://www.manton.org/2019/05/15/saying-goodbye-to.html