### PR TITLE
fix Backup/Restore preferences on Android 11+

### DIFF
--- a/app/src/main/java/com/klinker/android/twitter_l/settings/PrefFragment.java
+++ b/app/src/main/java/com/klinker/android/twitter_l/settings/PrefFragment.java
@@ -424,10 +424,11 @@ public class PrefFragment extends PreferenceFragment implements SharedPreference
                         .setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
                             @Override
                             public void onClick(DialogInterface dialogInterface, int i) {
-                                File des = new File(Environment.getExternalStorageDirectory() + "/Talon/backup.prefs");
+                                String desPath = context.getExternalFilesDir(null).getAbsolutePath() + "/backup.prefs";
+                                File des = new File(desPath);
                                 IOUtils.saveSharedPreferencesToFile(des, context);
 
-                                Toast.makeText(context, context.getResources().getString(R.string.backup_success) + ": /Talon/backup.prefs", Toast.LENGTH_LONG).show();
+                                Toast.makeText(context, context.getResources().getString(R.string.backup_success) + ": " + desPath, Toast.LENGTH_LONG).show();
                             }
                         })
                         .setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
@@ -450,7 +451,7 @@ public class PrefFragment extends PreferenceFragment implements SharedPreference
             @Override
             public boolean onPreferenceClick(Preference arg0) {
 
-                File des = new File(Environment.getExternalStorageDirectory() + "/Talon/backup.prefs");
+                File des = new File(context.getExternalFilesDir(null).getAbsolutePath() + "/backup.prefs");
 
                 String authenticationToken1 = sharedPrefs.getString("authentication_token_1", "none");
                 String authenticationTokenSecret1 = sharedPrefs.getString("authentication_token_secret_1", "none");


### PR DESCRIPTION
Just a small fix which removes the deprecated `getExternalStorageDirectory` in favour of the (scoped) `getExternalFilesDir`

This fixes the backup/restore preferences functionality on Android 11+.

As I'm not really versed in Android Storage best-practices and think that the new scoped, App specific, Storage is not optimal as the backup file will be deleted when you uninstall the App and the backup File is not easily accessible to other Apps I have marked this as a draft, suggested changes/improvements are more than welcome.

There might also be a few other, probably unrelated cosmetic bugs regarding the restore procedure, e.g. if i create a backup, change the theme from dark to light, restore the backup and then try to change the theme again to the light version the app is displayed with the dark theme but the selected entry is already/still the light theme.